### PR TITLE
Add Window.onWindowFocusChangedListeners API

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -32,5 +32,6 @@ object Dependencies {
     const val Orchestrator = "androidx.test:orchestrator:${Versions.AndroidXTest}"
     const val Rules = "androidx.test:rules:${Versions.AndroidXTest}"
     const val Runner = "androidx.test:runner:${Versions.AndroidXTest}"
+    const val UiAutomator = "androidx.test.uiautomator:uiautomator:2.2.0"
   }
 }

--- a/curtains/api/curtains.api
+++ b/curtains/api/curtains.api
@@ -144,6 +144,10 @@ public abstract interface class curtains/OnContentChangedListener {
 	public abstract fun onContentChanged ()V
 }
 
+public abstract interface class curtains/OnWindowFocusChangedListener {
+	public abstract fun onWindowFocusChanged (Z)V
+}
+
 public abstract interface class curtains/RootViewAddedListener : curtains/RootViewListener {
 	public abstract fun onRootViewAdded (Landroid/view/View;)V
 	public abstract fun onRootViewsChanged (Landroid/view/View;Z)V
@@ -191,6 +195,7 @@ public final class curtains/WindowType : java/lang/Enum {
 
 public final class curtains/WindowsKt {
 	public static final fun getOnContentChangedListeners (Landroid/view/Window;)Ljava/util/List;
+	public static final fun getOnWindowFocusChangedListeners (Landroid/view/Window;)Ljava/util/List;
 	public static final fun getPhoneWindow (Landroid/view/View;)Landroid/view/Window;
 	public static final fun getTouchEventInterceptors (Landroid/view/Window;)Ljava/util/List;
 	public static final fun getWindowAttachCount (Landroid/view/View;)I

--- a/curtains/build.gradle.kts
+++ b/curtains/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
   androidTestImplementation(Dependencies.InstrumentationTests.JUnit)
   androidTestImplementation(Dependencies.InstrumentationTests.Rules)
   androidTestImplementation(Dependencies.InstrumentationTests.Runner)
+  androidTestImplementation(Dependencies.InstrumentationTests.UiAutomator)
   androidTestImplementation(Dependencies.Truth)
   androidTestImplementation(Dependencies.AppCompat)
 

--- a/curtains/src/androidTest/AndroidManifest.xml
+++ b/curtains/src/androidTest/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.squareup.curtains.test">
 
   <!--
@@ -7,6 +8,8 @@
    Version 1.3.1 of the AndroidX Test libraries remove the need for this workaround.
    -->
   <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+
+  <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator" />
 
   <application>
     <activity android:name="curtains.test.utilities.TestActivity" />

--- a/curtains/src/androidTest/java/curtains/test/OnDecorViewReadyTest.kt
+++ b/curtains/src/androidTest/java/curtains/test/OnDecorViewReadyTest.kt
@@ -32,14 +32,14 @@ class OnDecorViewReadyTest {
   }
 
   @Test fun onDecorViewReady_triggers_immediately_if_contentView_set() {
+    val decorViewReady = CountDownLatch(1)
     ActivityScenario.launch(TestActivity::class.java).use { scenario ->
       scenario.onActivity { activity ->
-        val decorViewReady = CountDownLatch(1)
         activity.window.onDecorViewReady {
           decorViewReady.countDown()
         }
-        assertThat(decorViewReady).countsToZero()
       }
     }
+    assertThat(decorViewReady).countsToZero()
   }
 }

--- a/curtains/src/androidTest/java/curtains/test/OnWindowFocusChangedListenersTest.kt
+++ b/curtains/src/androidTest/java/curtains/test/OnWindowFocusChangedListenersTest.kt
@@ -1,0 +1,96 @@
+package curtains.test
+
+import android.app.AlertDialog
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import curtains.OnActivityCreated
+import curtains.OnWindowFocusChangedListener
+import curtains.onWindowFocusChangedListeners
+import curtains.test.utilities.TestActivity
+import curtains.test.utilities.application
+import curtains.test.utilities.assumeSdkAtMost
+import curtains.test.utilities.launchWaitingForFocus
+import curtains.test.utilities.registerUntilClosed
+import curtains.test.utilities.BlockingQueueSubject.Companion.assertThat
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.ArrayBlockingQueue
+
+class OnWindowFocusChangedListenersTest {
+
+  @Before
+  fun setUp() {
+    assumeSdkAtMost(29, "Can't repro locally: TestActivity never gets focus in CI on API 30")
+  }
+
+  @Test
+  fun activity_focus_gained_on_activity_resumed() {
+    val activityWindowFocusChanged = ArrayBlockingQueue<Boolean>(1)
+    application.registerUntilClosed(OnActivityCreated { activity, _ ->
+      if (activity !is TestActivity) {
+        return@OnActivityCreated
+      }
+      activity.window.onWindowFocusChangedListeners += object : OnWindowFocusChangedListener {
+        override fun onWindowFocusChanged(hasFocus: Boolean) {
+          activity.window.onWindowFocusChangedListeners -= this
+          activityWindowFocusChanged.put(hasFocus)
+        }
+      }
+    }).use {
+      ActivityScenario.launch(TestActivity::class.java).use {
+        assertThat(activityWindowFocusChanged).polls(true)
+      }
+    }
+  }
+
+  @Test
+  fun activity_focus_lost_on_activity_paused() {
+    val activityWindowFocusChanged = ArrayBlockingQueue<Boolean>(1)
+    launchWaitingForFocus(TestActivity::class).use { scenario ->
+      scenario.onActivity { activity ->
+        activity.window.onWindowFocusChangedListeners += object : OnWindowFocusChangedListener {
+          override fun onWindowFocusChanged(hasFocus: Boolean) {
+            activity.window.onWindowFocusChangedListeners -= this
+            activityWindowFocusChanged.put(hasFocus)
+          }
+        }
+      }
+      scenario.moveToState(Lifecycle.State.STARTED)
+      assertThat(activityWindowFocusChanged).polls(false)
+    }
+  }
+
+  @Test
+  fun activity_focus_lost_on_dialog_showed() {
+    val activityWindowFocusChanged = ArrayBlockingQueue<Boolean>(1)
+    launchWaitingForFocus(TestActivity::class).use { scenario ->
+      scenario.onActivity { activity ->
+        activity.window.onWindowFocusChangedListeners += object : OnWindowFocusChangedListener {
+          override fun onWindowFocusChanged(hasFocus: Boolean) {
+            activity.window.onWindowFocusChangedListeners -= this
+            activityWindowFocusChanged.put(hasFocus)
+          }
+        }
+        AlertDialog.Builder(activity).show()
+      }
+      assertThat(activityWindowFocusChanged).polls(false)
+    }
+  }
+
+  @Test
+  fun dialog_focus_gained_on_dialog_showed() {
+    val dialogWindowFocusChanged = ArrayBlockingQueue<Boolean>(1)
+    launchWaitingForFocus(TestActivity::class).use { scenario ->
+      scenario.onActivity { activity ->
+        val dialog = AlertDialog.Builder(activity).show()
+        dialog.window!!.onWindowFocusChangedListeners += object : OnWindowFocusChangedListener {
+          override fun onWindowFocusChanged(hasFocus: Boolean) {
+            dialog.window!!.onWindowFocusChangedListeners -= this
+            dialogWindowFocusChanged.put(hasFocus)
+          }
+        }
+      }
+      assertThat(dialogWindowFocusChanged).polls(true)
+    }
+  }
+}

--- a/curtains/src/androidTest/java/curtains/test/OnWindowFocusChangedListenersTest.kt
+++ b/curtains/src/androidTest/java/curtains/test/OnWindowFocusChangedListenersTest.kt
@@ -8,20 +8,13 @@ import curtains.OnWindowFocusChangedListener
 import curtains.onWindowFocusChangedListeners
 import curtains.test.utilities.TestActivity
 import curtains.test.utilities.application
-import curtains.test.utilities.assumeSdkAtMost
 import curtains.test.utilities.launchWaitingForFocus
 import curtains.test.utilities.registerUntilClosed
 import curtains.test.utilities.BlockingQueueSubject.Companion.assertThat
-import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.ArrayBlockingQueue
 
 class OnWindowFocusChangedListenersTest {
-
-  @Before
-  fun setUp() {
-    assumeSdkAtMost(29, "Can't repro locally: TestActivity never gets focus in CI on API 30")
-  }
 
   @Test
   fun activity_focus_gained_on_activity_resumed() {

--- a/curtains/src/androidTest/java/curtains/test/TouchEventInterceptorsTest.kt
+++ b/curtains/src/androidTest/java/curtains/test/TouchEventInterceptorsTest.kt
@@ -23,9 +23,9 @@ class TouchEventInterceptorsTest : HasActivityScenarioRule<TestActivity> {
   override val rule = ActivityScenarioRule(TestActivity::class.java)
 
   @Test fun touchEvent_dispatched_to_listeners() {
+    val touchEventReceived = CountDownLatch(2)
     onActivity { activity ->
       val cancelEvent = cancelEvent()
-      val touchEventReceived = CountDownLatch(2)
       activity.window.touchEventInterceptors += TouchEventListener { event ->
         touchEventReceived.countDown()
         assertThat(event).isSameInstanceAs(cancelEvent)
@@ -40,9 +40,8 @@ class TouchEventInterceptorsTest : HasActivityScenarioRule<TestActivity> {
       }
 
       rootView.dispatchTouchEvent(cancelEvent)
-
-      assertThat(touchEventReceived).countsToZero()
     }
+    assertThat(touchEventReceived).countsToZero()
   }
 
   @Test fun touchEvent_intercepted() {

--- a/curtains/src/androidTest/java/curtains/test/utilities/BlockingQueueSubject.kt
+++ b/curtains/src/androidTest/java/curtains/test/utilities/BlockingQueueSubject.kt
@@ -1,0 +1,45 @@
+package curtains.test.utilities
+
+import com.google.common.truth.Fact
+import com.google.common.truth.FailureMetadata
+import com.google.common.truth.IterableSubject
+import com.google.common.truth.Subject.Factory
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.TimeUnit
+
+class BlockingQueueSubject<E : Any> private constructor(
+    metadata: FailureMetadata,
+    private val actual: BlockingQueue<E>
+) : IterableSubject(metadata, actual) {
+
+  fun polls(expected: E) {
+    val actual = actual.poll(30, TimeUnit.SECONDS)
+        ?: return failWithoutActual(
+            Fact.simpleFact(
+                "Expected an element available within 30 seconds"
+            )
+        )
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  fun pollsNull() {
+    val actual = actual.poll()
+    assertThat(actual).isNull()
+  }
+
+  companion object {
+    fun <E : Any> queues(): Factory<BlockingQueueSubject<E>, BlockingQueue<E>> {
+      return Factory<BlockingQueueSubject<E>, BlockingQueue<E>> { metadata, actual ->
+        BlockingQueueSubject(
+            metadata, actual
+        )
+      }
+    }
+
+    fun <E : Any> assertThat(actual: BlockingQueue<E>): BlockingQueueSubject<E> {
+      return Truth.assertAbout(queues<E>()).that(actual)
+    }
+  }
+}

--- a/curtains/src/androidTest/java/curtains/test/utilities/TestUtils.kt
+++ b/curtains/src/androidTest/java/curtains/test/utilities/TestUtils.kt
@@ -16,7 +16,6 @@ import curtains.onWindowFocusChangedListeners
 import org.junit.Assume
 import java.io.Closeable
 import java.util.concurrent.ArrayBlockingQueue
-import java.util.concurrent.BlockingQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -69,12 +68,6 @@ fun assumeSdkAtLeast(
 fun CountDownLatch.checkAwait() {
   check(await(30, TimeUnit.SECONDS)) {
     "30 seconds elapsed without count coming down"
-  }
-}
-
-fun <E : Any> BlockingQueue<E>.checkPoll(): E {
-  return checkNotNull(poll(30, TimeUnit.SECONDS)) {
-    "30 seconds elapsed without an element becoming available"
   }
 }
 
@@ -134,7 +127,7 @@ private fun <T : Activity> ActivityScenario<T>.waitForFocus(): Boolean? {
       }
     }
   }
-  return activityHasWindowFocus.poll(10, TimeUnit.SECONDS) // TODO checkPoll
+  return activityHasWindowFocus.poll(10, TimeUnit.SECONDS)
 }
 
 private fun resolveAnr() {

--- a/curtains/src/main/java/curtains/Listeners.kt
+++ b/curtains/src/main/java/curtains/Listeners.kt
@@ -105,3 +105,13 @@ fun interface OnContentChangedListener {
    */
   fun onContentChanged()
 }
+
+/**
+ * Listener added to [Window.onWindowFocusChangedListeners].
+ */
+fun interface OnWindowFocusChangedListener {
+  /**
+   * Called when [android.view.Window.Callback.onWindowFocusChanged] is called.
+   */
+  fun onWindowFocusChanged(hasFocus: Boolean)
+}

--- a/curtains/src/main/java/curtains/Windows.kt
+++ b/curtains/src/main/java/curtains/Windows.kt
@@ -83,6 +83,19 @@ val Window.onContentChangedListeners: MutableList<OnContentChangedListener>
   }
 
 /**
+ * The list of window focus changed listeners, inserted in [Window.Callback.onWindowFocusChanged].
+ *
+ * Calling this has a side effect of wrapping the window callback (on first call).
+ *
+ * @throws IllegalStateException if not called from the main thread.
+ */
+val Window.onWindowFocusChangedListeners: MutableList<OnWindowFocusChangedListener>
+  get() {
+    checkMainThread()
+    return listeners.onWindowFocusChangedListeners
+  }
+
+/**
  * Calls [onDecorViewReady] with the decor view when the [android.view.Window] has a decor view
  * available.
  *

--- a/curtains/src/main/java/curtains/internal/WindowCallbackWrapper.kt
+++ b/curtains/src/main/java/curtains/internal/WindowCallbackWrapper.kt
@@ -46,6 +46,11 @@ internal class WindowCallbackWrapper constructor(
     delegate.onContentChanged()
   }
 
+  override fun onWindowFocusChanged(hasFocus: Boolean) {
+    listeners.onWindowFocusChangedListeners.forEach { it.onWindowFocusChanged(hasFocus) }
+    delegate.onWindowFocusChanged(hasFocus)
+  }
+
   companion object {
 
     private val jetpackWrapperClass by lazy(NONE) {

--- a/curtains/src/main/java/curtains/internal/WindowListeners.kt
+++ b/curtains/src/main/java/curtains/internal/WindowListeners.kt
@@ -1,6 +1,7 @@
 package curtains.internal
 
 import curtains.OnContentChangedListener
+import curtains.OnWindowFocusChangedListener
 import curtains.TouchEventInterceptor
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -11,4 +12,6 @@ internal class WindowListeners {
   val touchEventInterceptors = CopyOnWriteArrayList<TouchEventInterceptor>()
 
   val onContentChangedListeners = CopyOnWriteArrayList<OnContentChangedListener>()
+
+  val onWindowFocusChangedListeners = CopyOnWriteArrayList<OnWindowFocusChangedListener>()
 }


### PR DESCRIPTION
Following up on https://github.com/square/curtains/issues/3

The API largely continues what `OnContentChangedListener` established.

Tests check that the callback isn't invoked immediately with a current value (I don't think we know it anyway).
Tests check that activity focus changes after being resumed and before being paused.
There isn't a test case for activity gaining focus after a dialog is dismissed. At this point we're just testing the framework instead of the library, I think.
I ran tests locally on AOSP AVDs API 19 and 21-29.