### PR TITLE
Fix crash when no android x or support lib in classpath

### DIFF
--- a/curtains/src/main/java/curtains/internal/WindowCallbackWrapper.kt
+++ b/curtains/src/main/java/curtains/internal/WindowCallbackWrapper.kt
@@ -57,8 +57,11 @@ internal class WindowCallbackWrapper constructor(
       try {
         Class.forName("androidx.appcompat.view.WindowCallbackWrapper")
       } catch (ignored: Throwable) {
-        Class.forName("android.support.v7.view.WindowCallbackWrapper")
-        null
+        try {
+          Class.forName("android.support.v7.view.WindowCallbackWrapper")
+        } catch (ignored: Throwable) {
+          null
+        }
       }
     }
 


### PR DESCRIPTION
😅

I wish I could have a test for this but it's tricky to hide deps in tests except via separate modules.