### PR TITLE
kdoc to mention Google Mobile Ads doing stupid things

### DIFF
--- a/curtains/src/main/java/curtains/Curtains.kt
+++ b/curtains/src/main/java/curtains/Curtains.kt
@@ -48,7 +48,10 @@ object Curtains {
 
   /**
    * The list of listeners for newly attached or detached root views. It is safe to update this
-   * list from within [OnRootViewsChangedListener.onRootViewsChanged].
+   * list from within [OnRootViewsChangedListener.onRootViewsChanged], if called back on the main
+   * thread. New windows are typically added on the main thread, but it can also happen from a
+   * different thread by calling Dialog.show() from a background thread (and of course Google
+   * Mobile Ads does exactly that).
    *
    * If you only care about the attached state, you can implement the SAM interface
    * [OnRootViewAddedListener] which extends [OnRootViewsChangedListener].


### PR DESCRIPTION
This was surfaced in https://github.com/square/leakcanary/issues/2111 , stacktrace:

```
java.lang.IllegalStateException: Should be called from the main thread, not Thread[LooperProvider,5,main]
  at curtains.internal.HandlersKt.checkMainThread(HandlersKt.java:9)
  at curtains.WindowsKt.getWindowType(WindowsKt.java:37)
  at leakcanary.RootViewWatcher$listener$1.onRootViewAdded(RootViewWatcher.java:44)
  at curtains.OnRootViewAddedListener$DefaultImpls.onRootViewsChanged(OnRootViewAddedListener.java:37)
  at leakcanary.RootViewWatcher$listener$1.onRootViewsChanged(RootViewWatcher.java:43)
  at curtains.internal.RootViewsSpy$delegatingViewList$1.add(RootViewsSpy.java:25)
  at curtains.internal.RootViewsSpy$delegatingViewList$1.size(RootViewsSpy.java:23)
  at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:369)
  at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:93)
  at android.app.Dialog.show(Dialog.java:481)
  at com.google.android.gms.ads.internal.util.aj.b(aj.java:12)
  at com.google.android.gms.ads.internal.util.ad.run(ad.java)
  at android.os.Handler.handleCallback(Handler.java:873)
  at android.os.Handler.dispatchMessage(Handler.java:99)
  at qr.a(qr.java)
  at qr.dispatchMessage(qr.java)
  at android.os.Looper.loop(Looper.java:214)
  at android.os.HandlerThread.run(HandlerThread.java:65)
```

