### PR TITLE
Stop throwing when not on main thread

### DIFF
--- a/curtains/src/main/java/curtains/Curtains.kt
+++ b/curtains/src/main/java/curtains/Curtains.kt
@@ -2,10 +2,9 @@ package curtains
 
 import android.view.View
 import android.view.Window
-import curtains.Curtains.rootViews
 import curtains.Curtains.onRootViewsChangedListeners
+import curtains.Curtains.rootViews
 import curtains.internal.RootViewsSpy
-import curtains.internal.checkMainThread
 import kotlin.LazyThreadSafetyMode.NONE
 
 /**
@@ -22,8 +21,7 @@ import kotlin.LazyThreadSafetyMode.NONE
  *
  * [rootViews] returns a snapshot of the currently attached root views.
  *
- * All properties defined in this class must be accessed from the main thread and will otherwise
- * throw an [IllegalStateException].
+ * All properties defined in this class should be accessed from the main thread.
  *
  * [onRootViewsChangedListeners] allows apps to have a central place where they can interact with
  * newly added or removed windows. It's exposed as a mutable list to allow apps to reorder or
@@ -37,12 +35,10 @@ object Curtains {
 
   /**
    * @returns a copy of the list of root views held by [android.view.WindowManagerGlobal].
-   * @throws IllegalStateException if not called from the main thread.
    */
   @JvmStatic
   val rootViews: List<View>
     get() {
-      checkMainThread()
       return rootViewsSpy.copyRootViewList()
     }
 
@@ -65,13 +61,10 @@ object Curtains {
    * next view traversal.
    *
    * No-op below Android API 19, i.e. any listener added here will never be triggered.
-   *
-   * @throws IllegalStateException if not called from the main thread.
    */
   @JvmStatic
   val onRootViewsChangedListeners: MutableList<OnRootViewsChangedListener>
     get() {
-      checkMainThread()
       return rootViewsSpy.listeners
     }
 }

--- a/curtains/src/main/java/curtains/Windows.kt
+++ b/curtains/src/main/java/curtains/Windows.kt
@@ -1,3 +1,4 @@
+
 package curtains
 
 import android.os.Build
@@ -17,7 +18,6 @@ import curtains.internal.NextDrawListener.Companion.onNextDraw
 import curtains.internal.WindowCallbackWrapper.Companion.listeners
 import curtains.internal.WindowCallbackWrapper.Companion.unwrap
 import curtains.internal.WindowSpy
-import curtains.internal.checkMainThread
 import curtains.internal.frameMetricsHandler
 
 /**
@@ -27,18 +27,14 @@ import curtains.internal.frameMetricsHandler
  *
  * Note: this property is called [phoneWindow] because the only implementation of [Window] is
  * the internal class android.view.PhoneWindow.
- *
- * @throws IllegalStateException if not called from the main thread.
  */
 val View.phoneWindow: Window?
   get() {
-    checkMainThread()
     return WindowSpy.pullWindow(rootView)
   }
 
 val View.windowType: WindowType
   get() {
-    checkMainThread()
     val rootView = rootView
     if (WindowSpy.attachedToPhoneWindow(rootView)) {
       return PHONE_WINDOW
@@ -64,12 +60,9 @@ val View.windowType: WindowType
  * interface [OnTouchEventListener] which extends [TouchEventInterceptor].
  *
  * Calling this has a side effect of wrapping the window callback (on first call).
- *
- * @throws IllegalStateException if not called from the main thread.
  */
 val Window.touchEventInterceptors: MutableList<TouchEventInterceptor>
   get() {
-    checkMainThread()
     return listeners.touchEventInterceptors
   }
 
@@ -80,12 +73,9 @@ val Window.touchEventInterceptors: MutableList<TouchEventInterceptor>
  * interface [OnKeyEventListener] which extends [KeyEventInterceptor].
  *
  * Calling this has a side effect of wrapping the window callback (on first call).
- *
- * @throws IllegalStateException if not called from the main thread.
  */
 val Window.keyEventInterceptors: MutableList<KeyEventInterceptor>
   get() {
-    checkMainThread()
     return listeners.keyEventInterceptors
   }
 
@@ -93,12 +83,9 @@ val Window.keyEventInterceptors: MutableList<KeyEventInterceptor>
  * The list of content changed listeners, inserted in [Window.Callback.onContentChanged].
  *
  * Calling this has a side effect of wrapping the window callback (on first call).
- *
- * @throws IllegalStateException if not called from the main thread.
  */
 val Window.onContentChangedListeners: MutableList<OnContentChangedListener>
   get() {
-    checkMainThread()
     return listeners.onContentChangedListeners
   }
 
@@ -106,12 +93,9 @@ val Window.onContentChangedListeners: MutableList<OnContentChangedListener>
  * The list of window focus changed listeners, inserted in [Window.Callback.onWindowFocusChanged].
  *
  * Calling this has a side effect of wrapping the window callback (on first call).
- *
- * @throws IllegalStateException if not called from the main thread.
  */
 val Window.onWindowFocusChangedListeners: MutableList<OnWindowFocusChangedListener>
   get() {
-    checkMainThread()
     return listeners.onWindowFocusChangedListeners
   }
 
@@ -129,11 +113,8 @@ val Window.onWindowFocusChangedListeners: MutableList<OnWindowFocusChangedListen
  *
  * Calling this has a side effect of wrapping the window callback (on first call), unless
  * the decor view was already set.
- *
- * @throws IllegalStateException if not called from the main thread.
  */
 fun Window.onDecorViewReady(onDecorViewReady: (View) -> Unit) {
-  checkMainThread()
   val decorViewOrNull = peekDecorView()
   if (decorViewOrNull != null) {
     onDecorViewReady(decorViewOrNull)
@@ -170,8 +151,6 @@ fun Window.onDecorViewReady(onDecorViewReady: (View) -> Unit) {
  * the decor view was already set.
  *
  * No-op below Android API 16.
- *
- * @throws IllegalStateException if not called from the main thread.
  */
 fun Window.onNextDraw(onNextDraw: () -> Unit) {
   if (Build.VERSION.SDK_INT < 16) {
@@ -220,12 +199,9 @@ fun Window.onNextFrameMetrics(frameTimeNanos: Long, onNextFrameMetrics: (FrameMe
 /**
  * Returns [View.getWindowAttachCount] which has protected visibility and is normally only
  * accessible from within view subclasses.
- *
- * @throws IllegalStateException if not called from the main thread.
  */
 val View.windowAttachCount: Int
   get() {
-    checkMainThread()
     return windowAttachCount(this)
   }
 
@@ -242,7 +218,4 @@ val View.windowAttachCount: Int
  * happen.
  */
 val Window.Callback?.wrappedCallback: Window.Callback?
-  get() {
-    checkMainThread()
-    return unwrap()
-  }
+  get() = unwrap()

--- a/curtains/src/main/java/curtains/internal/Handlers.kt
+++ b/curtains/src/main/java/curtains/internal/Handlers.kt
@@ -11,9 +11,3 @@ internal val frameMetricsHandler by lazy {
   thread.start()
   Handler(thread.looper)
 }
-
-internal fun checkMainThread() {
-  check(Looper.getMainLooper().thread === Thread.currentThread()) {
-    "Should be called from the main thread, not ${Thread.currentThread()}"
-  }
-}

--- a/curtains/src/main/java/curtains/internal/WindowCallbackWrapper.kt
+++ b/curtains/src/main/java/curtains/internal/WindowCallbackWrapper.kt
@@ -120,23 +120,27 @@ internal class WindowCallbackWrapper constructor(
      */
     private val callbackCache = WeakHashMap<Window, WeakReference<WindowCallbackWrapper>>()
 
+    private val listenersLock = Any()
+
     val Window.listeners: WindowListeners
       get() {
-        val existingWrapper = callbackCache[this]?.get()
-        if (existingWrapper != null) {
-          return existingWrapper.listeners
-        }
+        synchronized(listenersLock) {
+          val existingWrapper = callbackCache[this]?.get()
+          if (existingWrapper != null) {
+            return existingWrapper.listeners
+          }
 
-        val currentCallback = callback
-        return if (currentCallback == null) {
-          // We expect a window to always have a default callback
-          // that we can delegate to, but who knows what apps can be up to.
-          WindowListeners()
-        } else {
-          val windowCallbackWrapper = WindowCallbackWrapper(currentCallback)
-          callback = windowCallbackWrapper
-          callbackCache[this] = WeakReference(windowCallbackWrapper)
-          windowCallbackWrapper.listeners
+          val currentCallback = callback
+          return if (currentCallback == null) {
+            // We expect a window to always have a default callback
+            // that we can delegate to, but who knows what apps can be up to.
+            WindowListeners()
+          } else {
+            val windowCallbackWrapper = WindowCallbackWrapper(currentCallback)
+            callback = windowCallbackWrapper
+            callbackCache[this] = WeakReference(windowCallbackWrapper)
+            windowCallbackWrapper.listeners
+          }
         }
       }
 


### PR DESCRIPTION
While Curtains APIs should be used from the main thread, there are a number edge cases as well as bugs in consuming SDKs / apps and the Android Framework SDKs that can trigger calls from the wrong thread, and in many cases there isn't much developers can do, so Curtains is relaxing the constraint and doing a best effort approach.